### PR TITLE
verify new urls before committing in updating mode

### DIFF
--- a/src/bin/updater/main.rs
+++ b/src/bin/updater/main.rs
@@ -98,10 +98,10 @@ fn main () {
         collectors.iter().for_each(|c| {
             match c.project.as_str() {
                 "routeviews" => {
-                    rv_futures.push(rv_scraper.scrape(c, opts.latest.clone(), Some(&conn), kafka_producer));
+                    rv_futures.push(rv_scraper.scrape(c, opts.latest.clone(), Some(&conn), kafka_producer, opts.latest.clone()));
                 }
                 "riperis" => {
-                    ris_futures.push(ris_scraper.scrape(c, opts.latest.clone(), Some(&conn), kafka_producer));
+                    ris_futures.push(ris_scraper.scrape(c, opts.latest.clone(), Some(&conn), kafka_producer, opts.latest.clone()));
                 }
                 _ => {panic!("")}
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,7 +25,7 @@ impl DataType {
     }
 }
 
-#[derive(Debug, Queryable, Insertable, Serialize, Deserialize)]
+#[derive(Debug, Queryable, Insertable, Serialize, Deserialize, Eq, PartialEq)]
 #[table_name="items"]
 pub struct Item {
     pub collector_id: String,

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -5,7 +5,68 @@ use crate::models::*;
 use crate::errors::*;
 use regex::Regex;
 use chrono::NaiveDateTime;
+use futures::future::join_all;
 
 pub use routeviews::RouteViewsScraper;
 pub use riperis::RipeRisScraper;
 use crate::db::DbConnection;
+
+async fn verify_urls(urls: &Vec<String>) -> Vec<String> {
+    let mut futures = vec![];
+    for url in urls{
+        futures.push(verify_url(url.as_str())
+        );
+    }
+    let res = join_all(futures).await;
+    let mut verified = vec![];
+    for (url, ready) in res {
+        if ready {
+            verified.push(url)
+        }
+    }
+
+    return verified
+}
+
+async fn verify_url(url: &str) -> (String, bool) {
+    let url_clone = url.to_string();
+    let res = match reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .or(Err(format!("{}", &url))) {
+        Ok(r) => {r}
+        Err(_) => {return (url_clone, false)}
+    };
+    if !res.status().is_success() {
+        return (url_clone, false)
+    }
+    let total_size = match res
+        .content_length(){
+        None => {0}
+        Some(l) => {l}
+    };
+
+    return if total_size > 0 {
+        (url_clone, true)
+    } else {
+        (url_clone, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_verify() {
+        let urls = verify_urls(
+            &vec![
+                "http://archive.routeviews.org/bgpdata/2022.02/RIBS/rib.20220221.0000.bz2".to_string(),
+                "http://archive.routeviews.org/route-views2.saopaulo/bgpdata/2022.02/RIBS/rib.20220221.0000.bz2".to_string(),
+                "http://archive.routeviews.org/route-views2.saopaulo/bgpdata/2022.02/RIBS/rib.20220221.0000.bz22".to_string(),
+            ]
+        ).await;
+        dbg!(urls);
+    }
+}


### PR DESCRIPTION
Add a new procedure to check file sizes for new URLs before committing data to the database. This allows us to better handle the cases where the URLs become available before the files are actually downloadable.

This fixes #3.