### PR TITLE
allow searching for files across different collectors

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -216,7 +216,8 @@ async def search_mrt_files(
                 return SearchResultModel(error=f"unknown project {project}: use 'routeviews' or 'riperis'")
 
         if collector_id:
-            query = query.filter(lambda i: i.collector_id == collector_id)
+            collectors = collector_id.replace(" ", "").split(",")
+            query = query.filter(lambda i: i.collector_id in collectors)
 
         query = query.order_by(Item.ts_start).page(page, page_size)
 


### PR DESCRIPTION
Multiple collectors are specified using a comma separated string. For example `rrc00,route-views2` would return all MRT files from `rrc00` and `route-views2` within the time range.

This resolves #11. Note that for projects, since we only have two projects currently supported, not specifying a project filter would return data from both projects.