### PR TITLE
Add new custom postgres docker image

### DIFF
--- a/deployment/Dockerfile.postgres
+++ b/deployment/Dockerfile.postgres
@@ -1,0 +1,6 @@
+FROM bitnami/postgresql:14
+
+USER 0
+RUN install_packages curl
+
+USER 1001

--- a/deployment/dbinit.sh
+++ b/deployment/dbinit.sh
@@ -1,4 +1,4 @@
-set -e
+# set -e
 
 echo "start bootstrapping database"
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3.1'
 
+name: bgpkit-broker
+
 networks:
   app-tier:
     driver: bridge
@@ -7,8 +9,10 @@ networks:
 services:
 
   postgres:
-    container_name: postgres
-    image: bitnami/postgresql:14
+    container_name: bgpkit-broker-postgres
+    build:
+      dockerfile: deployment/Dockerfile.postgres
+      context: ..
     restart: always
     env_file: db_cred.env
     volumes:
@@ -17,7 +21,7 @@ services:
     networks:
       - app-tier
 
-  bgpkit-broker-updater:
+  updater:
     container_name: bgpkit-broker-updater
     entrypoint: bash -c 'sleep 10; while !</dev/tcp/postgres/5432; do sleep 30; echo "wait for postgres"; done; service cron start; while true; do sleep 30; done;'
     build:
@@ -30,7 +34,7 @@ services:
     networks:
       - app-tier
 
-  bgpkit-broker-api:
+  api:
     container_name: bgpkit-broker-api
     entrypoint: bash -c 'sleep 10; while !</dev/tcp/postgres/5432; do sleep 30; echo "wait for postgres"; done; /usr/local/bin/start_api'
     ports:


### PR DESCRIPTION
The default `binami/postgres:14` image was updated to remove basic
commands like curl, thus causing the bootstrap script to fail (see #25).

This PR adds very thin customization to the bitnamic's Postgres
image by adding `RUN install_packages curl` to add curl to the image.
This resolves the issue.

The PR also cleans up the docker-compose file a bit with the
following changes:
- give the compose the name `bgpkit-broker`
- clean up service names, remove the `bgpkit-broker-` prefix
- add a custom Postgres container and build

This PR resolves issue #25.
